### PR TITLE
Update notebooks for internal recipes

### DIFF
--- a/mBuild_00_Getting_Started.ipynb
+++ b/mBuild_00_Getting_Started.ipynb
@@ -281,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_00_Getting_Started.ipynb
+++ b/mBuild_00_Getting_Started.ipynb
@@ -82,7 +82,7 @@
    "source": [
     "### Alkanes\n",
     "\n",
-    "The `Alkane` example class allows one to create an alkane chain with a chain length (in number of carbons) specified by the `n` argument.\n",
+    "The `Alkane` recipe class allows one to create an alkane chain with a chain length (in number of carbons) specified by the `n` argument.\n",
     "\n",
     "First, we will import the `Alkane` class and use Python's built-in `help` function to inspect the class constructor, which will reveal the arguments we are able to provide upon instantiation to customize our `Compound`."
    ]
@@ -93,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mbuild.examples import Alkane\n",
+    "from mbuild.lib.recipes.alkane import Alkane\n",
     "\n",
     "help(Alkane.__init__)"
    ]
@@ -159,9 +159,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Alkylsilane monolayers\n",
+    "### Monolayers\n",
     "\n",
-    "The `AlkaneMonolayer` class constructs an alkylsilane monolayer on crystalline silica.  The `pattern` argument can be used to tune where chains are placed on the surface. The `tile_x` and `tile_y` arguments can be used to replicate the surface in the $x$ and $y$ dimensions. And the `chain_length` argument can be used to tune the length of the alkylsilane chains.\n",
+    "The `Monolayer` class constructs a monolayer based on a user defined chain on a surface.  The `pattern` argument can be used to tune where chains are placed on the surface. The `tile_x` and `tile_y` arguments can be used to replicate the surface in the $x$ and $y$ dimensions.  Surface functionalization is examined in greater detail later in the tutorials.\n",
     "\n",
     "First, we'll import the class and take a look at its constructor."
    ]
@@ -172,16 +172,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mbuild.examples import AlkaneMonolayer\n",
+    "from mbuild.lib.recipes.monolayer import Monolayer\n",
     "\n",
-    "help(AlkaneMonolayer.__init__)"
+    "help(Monolayer.__init__)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we'll create a couple of different systems by varying the arguments we provide upon instantiation."
+    "Let us first import a surface to functionalize.  Here, we will import the betacristobalite silica surface."
    ]
   },
   {
@@ -190,69 +190,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "monolayer = AlkaneMonolayer(pattern=mb.Grid2DPattern(n=5, m=5), tile_x=1, tile_y=1, chain_length=20)\n",
+    "from mbuild.lib.surfaces.betacristobalite import Betacristobalite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we'll create a couple of different systems by varying the arguments we provide upon instantiation, afixing alkanes to the surface.\n",
+    "\n",
+    "First, let us consider creating a monolayer with alkanes of length 10 carbons. \n",
+    "\n",
+    "Note, the silica surface is periodic in the plane, with bonds between atoms that span the periodic boundary; at the current time these are not rendered properly. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monolayer = Monolayer(surface=Betacristobalite(), fractions=[1.0], chains=Alkane(n=10, cap_end=False), \n",
+    "                      pattern=mb.Grid2DPattern(n=5, m=5), tile_x=1, tile_y=1)\n",
     "monolayer.visualize()"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we will make several modifications.  First we'll set up the system to be 80% alkanes of length 10 and 20% alkanes of length 20. We'll randomly place 50 total chains on the the surface attachment sites, duplicating the silica lattice twice in the x-direction. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "monolayer = AlkaneMonolayer(pattern=mb.Random2DPattern(n=100), tile_x=2, tile_y=3, chain_length=5)\n",
+    "monolayer = Monolayer(surface=Betacristobalite(), fractions=[0.8, 0.2], \n",
+    "                      chains=[Alkane(n=10, cap_end=False), Alkane(n=20, cap_end=False)], \n",
+    "                      pattern=mb.Random2DPattern(n=50), tile_x=2, tile_y=1)\n",
     "monolayer.visualize()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Tethered nanospheres\n",
-    "\n",
-    "The `Tnp` class is a bit more abstract than our previous two classes, and defines a nanoparticle constructed of uniformly spaced beads featuring arbitrary polymer tethers. The `ball_radius` class can be used to tune the size of the nanoparticle. While the `n_chains` and `chain_length` arguments can be used to tune the number and length of the polymer tethers.\n",
-    "\n",
-    "Again, we'll first import the class and view the constructor."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from mbuild.examples.tnp.tnp import Tnp\n",
-    "\n",
-    "help(Tnp.__init__)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we'll create a couple variations."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "tnp = Tnp(ball_radius=10, n_chains=4, chain_length=10)\n",
-    "tnp.visualize()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tnp = Tnp(ball_radius=5, n_chains=20, chain_length=5)\n",
-    "tnp.visualize()"
    ]
   },
   {
@@ -281,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/mBuild_01_Basic_Functionality.ipynb
+++ b/mBuild_01_Basic_Functionality.ipynb
@@ -228,13 +228,6 @@
     "\n",
     "In the next tutorial you will learn about wrapping routines for creating `Compounds` into classes for reusability."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -253,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_02_Reusing_Components.ipynb
+++ b/mBuild_02_Reusing_Components.ipynb
@@ -179,13 +179,6 @@
     "\n",
     "The next tutorial will demonstrate how another of mBuild's base classes, the `Port` class, can be used to create connections (bonds) between `Compounds` and move them in space."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -204,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_03_Connecting_Components_with_Ports.ipynb
+++ b/mBuild_03_Connecting_Components_with_Ports.ipynb
@@ -237,13 +237,6 @@
     "\n",
     "The next tutorial will take the routines we've learned and use them to create a more complex molecule, an alkane chain."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -262,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_04_Constructing_Larger_Compounds.ipynb
+++ b/mBuild_04_Constructing_Larger_Compounds.ipynb
@@ -269,13 +269,6 @@
     "\n",
     "The next tutorial will teach you how to create mBuild `Compound` classes with arguments that allow you to tune the molecular chemistry upon instantiation."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -294,7 +287,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_05_Creating_Flexible_Classes.ipynb
+++ b/mBuild_05_Creating_Flexible_Classes.ipynb
@@ -209,13 +209,6 @@
     "\n",
     "The next tutorial will teach you how to create systems of bulk molecules."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -234,7 +227,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_06_Setting_Up_Bulk_Systems.ipynb
+++ b/mBuild_06_Setting_Up_Bulk_Systems.ipynb
@@ -291,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/mBuild_06_Setting_Up_Bulk_Systems.ipynb
+++ b/mBuild_06_Setting_Up_Bulk_Systems.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mbuild.examples import Alkane\n",
+    "from mbuild.lib.recipes.alkane import Alkane\n",
     "\n",
     "hexane = Alkane(6)\n",
     "\n",
@@ -273,13 +273,6 @@
     "\n",
     "The next tutorial will teach you how to use mBuild's built-in energy minimization routine."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -298,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_07_Energy_Minimization.ipynb
+++ b/mBuild_07_Energy_Minimization.ipynb
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mbuild.examples import Alkane\n",
+    "from mbuild.lib.recipes.alkane import Alkane\n",
     "hexane = Alkane(6)\n",
     "hexane.visualize()"
    ]
@@ -142,13 +142,6 @@
     "\n",
     "The next tutorial will teach you how you can use mBuild to create polymers."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -167,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_08_Building_Polymers.ipynb
+++ b/mBuild_08_Building_Polymers.ipynb
@@ -24,7 +24,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import mbuild as mb"
+    "import mbuild as mb\n",
+    "\n",
+    "from mbuild.lib.recipes.polymer import Polymer\n",
+    "\n"
    ]
   },
   {
@@ -83,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alkane = mb.Polymer(monomers=CH2(), n=6, port_labels=('up', 'down'))\n",
+    "alkane = Polymer(monomers=CH2(), n=6, port_labels=('up', 'down'))\n",
     "alkane.visualize()"
    ]
   },
@@ -104,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "peg4 = mb.Polymer(monomers=(CH2(), O()), sequence='AAB', n=4, port_labels=('up', 'down'))\n",
+    "peg4 = Polymer(monomers=(CH2(), O()), sequence='AAB', n=4, port_labels=('up', 'down'))\n",
     "peg4.visualize(show_ports=True)"
    ]
   },
@@ -121,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "polymer = mb.Polymer(monomers=(CH2(), O()), sequence='AABAABBBB', n=3, port_labels=('up', 'down'))\n",
+    "polymer = Polymer(monomers=(CH2(), O()), sequence='AABAABBBB', n=3, port_labels=('up', 'down'))\n",
     "polymer.visualize()"
    ]
   },
@@ -168,7 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "semifluorinated_hexane = mb.Polymer(monomers=(CH2(), CF2()), sequence='AAABBB', n=1, port_labels=('up', 'down'))\n",
+    "semifluorinated_hexane = Polymer(monomers=(CH2(), CF2()), sequence='AAABBB', n=1, port_labels=('up', 'down'))\n",
     "semifluorinated_hexane.visualize()"
    ]
   },
@@ -192,10 +195,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alkane_block = mb.Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
-    "pfa_block = mb.Polymer(monomers=CF2(), n=3, port_labels=('up', 'down'))\n",
+    "alkane_block = Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
+    "pfa_block = Polymer(monomers=CF2(), n=3, port_labels=('up', 'down'))\n",
     "\n",
-    "semifluorinated_hexane = mb.Polymer(monomers=(alkane_block, pfa_block), sequence='AB', n=1, port_labels=('up', 'down'))\n",
+    "semifluorinated_hexane = Polymer(monomers=(alkane_block, pfa_block), sequence='AB', n=1, port_labels=('up', 'down'))\n",
     "\n",
     "semifluorinated_hexane.visualize()"
    ]
@@ -218,10 +221,10 @@
     "        super(Semifluorinated, self).__init__()\n",
     "        \n",
     "        \n",
-    "        alkane_block = mb.Polymer(monomers=CH2(), n=alkane_length, port_labels=('up', 'down'))\n",
-    "        pfa_block = mb.Polymer(monomers=CF2(), n=pfa_length, port_labels=('up', 'down'))\n",
+    "        alkane_block = Polymer(monomers=CH2(), n=alkane_length, port_labels=('up', 'down'))\n",
+    "        pfa_block = Polymer(monomers=CF2(), n=pfa_length, port_labels=('up', 'down'))\n",
     "\n",
-    "        semifluorinated_hexane = mb.Polymer(monomers=(alkane_block, pfa_block), sequence='AB', n=1, port_labels=('up', 'down'))        \n",
+    "        semifluorinated_hexane = Polymer(monomers=(alkane_block, pfa_block), sequence='AB', n=1, port_labels=('up', 'down'))        \n",
     "        self.add(semifluorinated_hexane)\n",
     "\n",
     "semifluorinated_alkane = Semifluorinated(alkane_length=5, pfa_length=3)\n",
@@ -258,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/mBuild_08_Building_Polymers.ipynb
+++ b/mBuild_08_Building_Polymers.ipynb
@@ -240,13 +240,6 @@
     "\n",
     "The next tutorial will teach you how you can use mBuild to functionalize surfaces."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -265,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_09_Surface_Functionalization.ipynb
+++ b/mBuild_09_Surface_Functionalization.ipynb
@@ -309,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/mBuild_09_Surface_Functionalization.ipynb
+++ b/mBuild_09_Surface_Functionalization.ipynb
@@ -90,10 +90,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mbuild.lib.bulk_materials import AmorphousSilica\n",
-    "from mbuild.recipes import SilicaInterface\n",
+    "from mbuild.lib.bulk_materials import AmorphousSilicaBulk\n",
+    "from mbuild.lib.recipes import SilicaInterface\n",
     "\n",
-    "surface = SilicaInterface(bulk_silica=AmorphousSilica())\n",
+    "surface = SilicaInterface(bulk_silica=AmorphousSilicaBulk())\n",
     "surface.visualize(show_ports=True)"
    ]
   },
@@ -117,10 +117,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from mbuild.lib.recipes import Polymer\n",
+    "\n",
+    "\n",
     "surface = Betacristobalite()\n",
     "\n",
-    "alkane_12 = mb.Polymer(monomers=CH2(), n=12, port_labels=('up', 'down'))\n",
-    "alkane_3 = mb.Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
+    "alkane_12 = Polymer(monomers=CH2(), n=12, port_labels=('up', 'down'))\n",
+    "alkane_3 = Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
     "pattern = mb.Grid2DPattern(5, 5)\n",
     "guests, backfills = pattern.apply_to_compound(guest=alkane_12, host=surface, backfill=alkane_3, backfill_port_name='down')\n",
     "functionalized_surface = mb.Compound(subcompounds=[surface, guests, backfills])\n",
@@ -140,12 +143,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "surface = SilicaInterface(bulk_silica=AmorphousSilica())\n",
-    "alkane_18 = mb.Polymer(monomers=CH2(), n=18, port_labels=('up', 'down'))\n",
-    "alkane_12 = mb.Polymer(monomers=CH2(), n=12, port_labels=('up', 'down'))\n",
-    "alkane_3 = mb.Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
+    "from mbuild.lib.recipes import Monolayer\n",
     "\n",
-    "monolayer = mb.Monolayer(surface=surface, chains=(alkane_3, alkane_12, alkane_18), fractions=(0.5, 0.4, 0.1))\n",
+    "surface = SilicaInterface(bulk_silica=AmorphousSilicaBulk())\n",
+    "alkane_18 = Polymer(monomers=CH2(), n=18, port_labels=('up', 'down'))\n",
+    "alkane_12 = Polymer(monomers=CH2(), n=12, port_labels=('up', 'down'))\n",
+    "alkane_3 = Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
+    "\n",
+    "monolayer = Monolayer(surface=surface, chains=(alkane_3, alkane_12, alkane_18), fractions=(0.5, 0.4, 0.1))\n",
     "monolayer.visualize()"
    ]
   },
@@ -217,7 +222,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mbuild.examples import Alkane\n",
+    "from mbuild.lib.recipes.alkane import Alkane\n",
     "\n",
     "class S(mb.Compound):\n",
     "    def __init__(self):\n",
@@ -272,7 +277,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "monolayer = mb.Monolayer(surface=gold_with_ports, chains=butanethiol)\n",
+    "monolayer = Monolayer(surface=gold_with_ports, chains=butanethiol)\n",
     "monolayer.visualize()"
    ]
   },
@@ -286,13 +291,6 @@
     "\n",
     "The goal of this tutorial was to demonstrate how to functionalize surfaces using mBuild."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -311,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/mBuild_10_Constructing_Lattices.ipynb
+++ b/mBuild_10_Constructing_Lattices.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -26,7 +24,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #8, thanks to @jpotoff for the tip-off

I ran each of the notebooks myself, and double-checked that they work after my changes (except for one). I would like at least one other person to run them to verify they work, not just work on my machine.

* All `mbuild.examples` imports are moved to their locations, except `mbuild.examples.tnp.TNP` which no longer exists

* Empty cells at the end of each notebook have been removed
* The lattice notebook is empty @justinGilmer 